### PR TITLE
Add action to update v1 on every merge to 1.x

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+
+jobs:
+
+  tag-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Re-tag v1
+        # Note, the current `v1` tag won't have been pulled by "checkout" above, so we can just create a new one
+        run: git tag v1 && git show --no-patch v1
+
+      - name: Publish v1
+        run: git push -f origin v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,10 @@ name: Release
 
 on:
   push:
+    branches:
+      # Only release on the 1.x branch.
+      # In future, we would probably trigger this off a `release` event but this will get us going
+      - '1.x'
 
 jobs:
 


### PR DESCRIPTION
In due course we might want to move to proper releases and update the v1 tag on an actual release. 

But for now this lets us use future-compatible tag versioning in the projects consuming the actions.